### PR TITLE
Modification des tracepoints pour PtaskTracer pour les dates de réveil 

### DIFF
--- a/examples/tracer_example.c
+++ b/examples/tracer_example.c
@@ -8,9 +8,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define PER 50  //task period
+#define PER 70  //task period
 #define RNT 20   //task runtime
-#define DREL 25 //task deadline
+#define DREL 30 //task deadline
 #define PRIO 30 //task priority
 #define TT 1    //task forced time
 
@@ -22,7 +22,8 @@ void init() {
 
 
 void task() {
-    for (int i=0; i<1000; i++) {
+	int i;
+    for ( i=0; i<1000; i++) {
         work_for(5, MILLI);
         //printf("Done\n");
         ptask_wait_for_period();
@@ -42,7 +43,7 @@ void activ_aper_task()
     int task_to_activate = *((int*) ptask_get_argument());
     int i = 0;
     while(1) {
-        if (i%3 == 0) work_for(15, MILLI);
+        if (i%3 == 0) work_for(10, MILLI);
         else work_for(5, MILLI);
         
         if (i%2 == 0) ptask_activate(task_to_activate);
@@ -55,55 +56,25 @@ void activ_aper_task()
  
 int main(void) {
     int i, j;
-    int aper, act_aper;
-
+    int aper, act_aper, aper2, aper3, act_aper2, act_aper3, aper4, act_aper4, aper5, act_aper5;
     init();
 
-    tpars params = TASK_SPEC_DFL;
-    params.period = tspec_from(PER, MILLI);
-    params.rdline = tspec_from(DREL, MILLI);
-    params.measure_flag = 1;
-    params.processor = 0;
-    params.act_flag = DEFERRED;
-    params.runtime = tspec_from(RNT, MILLI);
-    params.priority = PRIO;
-    
-    i = ptask_create_param(task, &params);
-    if (i != -1) printf("Task %d created and activated\n", i);
-    else exit(-1);
-    ptask_activate_at(i, 50, MILLI);
-    
-    params.priority = PRIO - i;
-    j = ptask_create_param(task, &params);
-    if (j != -1) printf("Task %d created and activated\n", j);
-    else exit(-1);
-    ptask_activate_at(j, 50, MILLI);
-    
-    /* params.priority = PRIO - j; */
-    /* k = ptask_create_param(task, &params); */
-    /* if (k != -1) printf("Task %d created and activated\n", k); */
-    /* else exit(-1); */
-    /* ptask_activate_at(k, 50, MILLI); */
-    
-    /* params.priority = PRIO - k; */
-    /* l = ptask_create_param(task, &params); */
-    /* if (l != -1) printf("Task %d created and activated\n", l); */
-    /* else exit(-1); */
-    /* ptask_activate_at(l, 50, MILLI); */
+	tpars params = TASK_SPEC_DFL;
+	params.period = tspec_from(PER, MILLI);
+	params.rdline = tspec_from(DREL, MILLI);
+	params.measure_flag = 1;
+	params.processor = 0;
+	params.act_flag = DEFERRED;
+	params.runtime = tspec_from(RNT, MILLI);
+	params.priority = PRIO;
 
-    /* params.priority = PRIO - l; */
-    /* m = ptask_create_param(task, &params); */
-    /* if (m != -1) printf("Task %d created and activated\n", m); */
-    /* else exit(-1); */
-    /* ptask_activate_at(m, 50, MILLI); */
+/*	i = ptask_create_param(task, &params);
+	if (i != -1) printf("Task %d created and activated\n", i);
+	else exit(-1);
+	ptask_activate_at(i, 50, MILLI);
 
-    /* params.priority = PRIO - m; */
-    /* n = ptask_create_param(task, &params); */
-    /* if (n != -1) printf("Task %d created and activated\n", n); */
-    /* else exit(-1); */
-    /* ptask_activate_at(n, 50, MILLI); */
 
-    aper = ptask_create_param(aper_task, &params);
+	aper = ptask_create_param(aper_task, &params);
     if (aper != -1) printf("Task %d created and activated\n", aper);
     else exit(-1);
 
@@ -112,8 +83,90 @@ int main(void) {
     if (act_aper != -1) printf("Task %d created and activated\n", act_aper);
     else exit(-1);
     ptask_activate_at(act_aper, 50, MILLI);
+*/
+
+	aper2 = ptask_create_param(aper_task, &params);
+    if (aper2 != -1) printf("Task %d created and activated\n", aper2);
+    else exit(-1);
+
+	params.arg = &aper2;
+    act_aper2 = ptask_create_param(activ_aper_task, &params);
+    if (act_aper2 != -1) printf("Task %d created and activated\n", act_aper2);
+    else exit(-1);
+    ptask_activate_at(act_aper2, 50, MILLI);
+
+	
+/*	aper3 = ptask_create_param(aper_task, &params);
+    if (aper3 != -1) printf("Task %d created and activated\n", aper3);
+    else exit(-1);
+	
+	params.arg = &aper3;
+    act_aper3 = ptask_create_param(activ_aper_task, &params);
+    if (act_aper3 != -1) printf("Task %d created and activated\n", act_aper3);
+    else exit(-1);
+    ptask_activate_at(act_aper3, 50, MILLI);
+ 
+
+	aper4 = ptask_create_param(aper_task, &params);
+    if (aper4 != -1) printf("Task %d created and activated\n", aper4);
+    else exit(-1);
+	
+	params.arg = &aper4;
+    act_aper4 = ptask_create_param(activ_aper_task, &params);
+    if (act_aper4 != -1) printf("Task %d created and activated\n", act_aper4);
+    else exit(-1);
+    ptask_activate_at(act_aper4, 50, MILLI);
+
+
+	aper5 = ptask_create_param(aper_task, &params);
+    if (aper5 != -1) printf("Task %d created and activated\n", aper5);
+    else exit(-1);
+	
+	params.arg = &aper5;
+	act_aper5 = ptask_create_param(activ_aper_task, &params);
+	if (act_aper5 != -1) printf("Task %d created and activated\n", act_aper5);
+	else exit(-1);
+	ptask_activate_at(act_aper5, 50, MILLI);
+
+
+	params.priority = PRIO - i;
+	j = ptask_create_param(task, &params);
+	if (j != -1) printf("Task %d created and activated\n", j);
+	else exit(-1);
+	ptask_activate_at(j, 50, MILLI);
+
+
+	int k;
+	params.priority = PRIO - j; 
+	k = ptask_create_param(task, &params); 
+	if (k != -1) printf("Task %d created and activated\n", k); 
+	else exit(-1); 
+	ptask_activate_at(k, 50, MILLI); 
     
+	int l;
+	params.priority = PRIO - k;
+	l = ptask_create_param(task, &params);
+	if (l != -1) printf("Task %d created and activated\n", l);
+	else exit(-1);
+	ptask_activate_at(l, 50, MILLI);
+
+	int m;
+	params.priority = PRIO - l;
+	m = ptask_create_param(task, &params);
+	if (m != -1) printf("Task %d created and activated\n", m);
+	else exit(-1);
+	ptask_activate_at(m, 50, MILLI);
+
+	int n;
+	params.priority = PRIO - m;
+	n = ptask_create_param(task, &params);
+	if (n != -1) printf("Task %d created and activated\n", n);
+	else exit(-1);
+	ptask_activate_at(n, 50, MILLI);*/
+
+
     while(1) ;
     
     return 0;
 }
+

--- a/src/ptask.c
+++ b/src/ptask.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 #ifdef TRACEPOINT_DEFINE
 #define TRACEPOINT_CREATE_PROBES
@@ -144,7 +145,9 @@ static void *ptask_std_body(void *arg) {
     else {
         clock_gettime(CLOCK_MONOTONIC, &t);
         _tp[ptask_idx].dl = tspec_add(&t, &_tp[ptask_idx].deadline);
+		_tp[ptask_idx].actual_at = t;
         _tp[ptask_idx].at = tspec_add(&t, &_tp[ptask_idx].period);
+
     }
 
     
@@ -210,7 +213,7 @@ void tpoint(char* flag, char* state) {
     pid_t pid = getpid();
     struct timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
-    tracepoint(ptask_provider, ptask_tracepoint, pid, _tp[ptask_idx].tid, ptask_idx, flag, state, tspec_to_rel(&now, MILLI), _tp[ptask_idx].priority, tspec_to(&_tp[ptask_idx].period, MICRO), tspec_to(&_tp[ptask_idx].deadline, MICRO), tspec_to(&_tp[ptask_idx].reloffset, MICRO));
+    tracepoint(ptask_provider, ptask_tracepoint, pid, _tp[ptask_idx].tid, ptask_idx, flag, state, tspec_to_rel(&now, MILLI), _tp[ptask_idx].priority, tspec_to(&_tp[ptask_idx].period, MICRO), tspec_to(&_tp[ptask_idx].deadline, MICRO), tspec_to_rel(&_tp[ptask_idx].actual_at,MICRO));
 }
 #endif
 
@@ -326,7 +329,6 @@ int ptask_create_edf(void (*task)(void), int period, int runtime, int dline,
 }
 
 void ptask_wait_for_period() {
-
 #ifdef TRACEPOINT_DEFINE
     if(_tp[ptask_idx].act_flag == NOW) tpoint("NOW", "b_wait_period");
     else if(_tp[ptask_idx].act_flag == DEFERRED) tpoint("DEFERRED", "b_wait_period");
@@ -358,8 +360,9 @@ void ptask_wait_for_period() {
         /* update absolute deadline */
         _tp[ptask_idx].dl =
             tspec_add(&(_tp[ptask_idx].at), &_tp[ptask_idx].deadline);
-
+	
         /* when awaken, update next activation time */
+		_tp[ptask_idx].actual_at = _tp[ptask_idx].at;
         _tp[ptask_idx].at =
             tspec_add(&(_tp[ptask_idx].at), &_tp[ptask_idx].period);
 
@@ -402,7 +405,6 @@ void ptask_wait_for_activation() {
         _tp[ptask_idx].offset = tspec_zero;
     }
     pthread_mutex_unlock(&_tp[ptask_idx].mux);
-
 #ifdef TRACEPOINT_DEFINE
     if(_tp[ptask_idx].act_flag == NOW) tpoint("NOW", "e_wait_activation");
     else if(_tp[ptask_idx].act_flag == DEFERRED) tpoint("DEFERRED", "e_wait_activation");
@@ -606,24 +608,17 @@ int ptask_activate(int i) {
         ret = -1;
     } else {
 
-		#ifdef TRACEPOINT_DEFINE
-		int tmp_ptask_idx=ptask_idx;
-		ptask_idx=i;
-		if(_tp[ptask_idx].act_flag == NOW) tpoint("NOW", "activation");
-		else if(_tp[ptask_idx].act_flag == DEFERRED) tpoint("DEFERRED", "activation");
-		ptask_idx=tmp_ptask_idx;
-		#endif
-
         clock_gettime(CLOCK_MONOTONIC, &t);
 		
         /* compute the absolute deadline */
         _tp[i].dl = tspec_add(&t, &_tp[i].deadline);
 
         /* compute the next activation time */
+		_tp[i].actual_at = t;
         _tp[i].at = tspec_add(&t, &_tp[i].period);
-
         /* send the activation signal */
         sem_post(&_tsem[i]);
+
     }
     pthread_mutex_unlock(&_tp[i].mux);
     return ret;
@@ -631,7 +626,6 @@ int ptask_activate(int i) {
 
 int ptask_activate_at(int i, ptime offset, int unit) {
     tspec reloff = tspec_from(offset, unit);
-	_tp[i].reloffset = reloff;
     tspec t;
     int ret = 1;
 
@@ -642,15 +636,18 @@ int ptask_activate_at(int i, ptime offset, int unit) {
         ret = -1;
     } else {
         t = tspec_get_ref();
+		
         /* compute the absolute deadline */
         _tp[i].offset = tspec_add(&t, &reloff);
         _tp[i].dl = tspec_add(&_tp[i].offset, &_tp[i].deadline);
-        /* compute the next activation time */
+        /* compute the next activation time */ 
+		_tp[i].actual_at = _tp[i].offset;
         _tp[i].at = tspec_add(&_tp[i].offset, &_tp[i].period);
         /* send the activation signal */
         sem_post(&_tsem[i]);
         // printf("sem_post done on task %d\n", i);
     }
+
     pthread_mutex_unlock(&_tp[i].mux);
     return ret;
 }

--- a/src/ptask.h
+++ b/src/ptask.h
@@ -60,9 +60,9 @@ struct task_par {
     int priority;        /* task priority in [0,99]	    */
     int dmiss;           /* number of deadline misses  	*/
     tspec at;            /* next activation time	     	*/
+	tspec actual_at;     /* activation time  */
     tspec dl;            /* current absolute deadline	*/
     tspec offset;        /* offset from activation time  */
-	tspec reloffset;     /* relative offset from activation time  */
     void (*body)(void);  /* the actual body of the task  */
     int free;            /* >=0 if this descr is avail.  */
     int act_flag;        /* flag for postponed activ.    */

--- a/src/ptask.h
+++ b/src/ptask.h
@@ -62,6 +62,7 @@ struct task_par {
     tspec at;            /* next activation time	     	*/
     tspec dl;            /* current absolute deadline	*/
     tspec offset;        /* offset from activation time  */
+	tspec reloffset;     /* relative offset from activation time  */
     void (*body)(void);  /* the actual body of the task  */
     int free;            /* >=0 if this descr is avail.  */
     int act_flag;        /* flag for postponed activ.    */

--- a/src/tpt_provider.h
+++ b/src/tpt_provider.h
@@ -10,30 +10,32 @@
 #include <lttng/tracepoint.h>
 
 TRACEPOINT_EVENT(
-    ptask_provider,
-    ptask_tracepoint,
-    TP_ARGS(
+	ptask_provider,
+	ptask_tracepoint,
+	TP_ARGS(
 		int, pid,
 		int, tid,
-        int, i,
+		int, i,
 		char*, flag,
 		char*, state,
 		long, time,
 		int, priority,
 		int, period,
-		int, deadline
-    ),
-    TP_FIELDS(
+		int, deadline,
+		int, offset
+	),
+	TP_FIELDS(
 		ctf_integer(int, ptask_pid, pid)
-        ctf_integer(int, ptask_tid, tid)
-        ctf_integer(int, ptask_index, i)
+		ctf_integer(int, ptask_tid, tid)
+		ctf_integer(int, ptask_index, i)
 		ctf_string(ptask_flag, flag)
 		ctf_string(ptask_state, state)
-        ctf_integer(long, ptask_time, time)
-        ctf_integer(int, ptask_priority, priority)
-        ctf_integer(int, ptask_period, period)
-        ctf_integer(int, ptask_deadline, deadline)
-    )
+		ctf_integer(long, ptask_time, time)
+		ctf_integer(int, ptask_priority, priority)
+		ctf_integer(int, ptask_period, period)
+		ctf_integer(int, ptask_deadline, deadline)
+		ctf_integer(int, ptask_offset, offset)
+	)
 )
 
 TRACEPOINT_LOGLEVEL(ptask_provider, ptask_tracepoint, TRACE_INFO)

--- a/src/tpt_provider.h
+++ b/src/tpt_provider.h
@@ -22,7 +22,7 @@ TRACEPOINT_EVENT(
 		int, priority,
 		int, period,
 		int, deadline,
-		int, offset
+		long, actual_at
 	),
 	TP_FIELDS(
 		ctf_integer(int, ptask_pid, pid)
@@ -34,7 +34,7 @@ TRACEPOINT_EVENT(
 		ctf_integer(int, ptask_priority, priority)
 		ctf_integer(int, ptask_period, period)
 		ctf_integer(int, ptask_deadline, deadline)
-		ctf_integer(int, ptask_offset, offset)
+		ctf_integer(long, ptask_actual_at, actual_at)
 	)
 )
 


### PR DESCRIPTION
Ajout d'un nouveau champ dans les tracepoints : l'offset pour connaître calculer la date de réveil de la tâche Cet offset est stocké dans la structure des tâches périodiques

Nouveau tracepoint lors de l'activation d'une tâche apériodique lors de l'appel à ptask_activate() pour obtenir les dates de réveil des tâches apériodiques